### PR TITLE
Animecix guncelleme

### DIFF
--- a/AnimeciX/build.gradle.kts
+++ b/AnimeciX/build.gradle.kts
@@ -12,7 +12,7 @@ cloudstream {
      * 2: Slow
      * 3: Beta only
     **/
-    status  = 0 // will be 3 if unspecified
+    status  = 1 // will be 3 if unspecified
     tvTypes = listOf("Anime")
     iconUrl = "https://www.google.com/s2/favicons?domain=animecix.net&sz=%size%"
 }

--- a/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
+++ b/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
@@ -31,7 +31,7 @@ class AnimeciX : MainAPI() {
         val home     = response?.pagination?.data?.mapNotNull { anime ->
             newAnimeSearchResponse(
                 anime.title,
-                "${mainUrl}/secure/titles/${anime.id}?titleId=${anime.id}&titleName=${uselessTitleName}",
+                "${mainUrl}/secure/titles/${anime.id}?titleId=${anime.id}",
                 TvType.Anime
             ) {
                 this.posterUrl = fixUrlNull(anime.poster)
@@ -47,7 +47,7 @@ class AnimeciX : MainAPI() {
         return response.results.mapNotNull { anime ->
             newAnimeSearchResponse(
                 anime.title,
-                "${mainUrl}/secure/titles/${anime.id}?titleId=${anime.id}&titleName=${uselessTitleName}",
+                "${mainUrl}/secure/titles/${anime.id}?titleId=${anime.id}",
                 TvType.Anime
             ) {
                 this.posterUrl = fixUrlNull(anime.poster)

--- a/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
+++ b/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
@@ -11,8 +11,8 @@ import com.lagradost.cloudstream3.LoadResponse.Companion.addTrailer
 class AnimeciX : MainAPI() {
     override var mainUrl              = "https://animecix.net"
     override var sequentialMainPage = true
-    override var sequentialMainPageDelay = 200
-    override var sequentialMainPageScrollDelay = 200
+    override var sequentialMainPageDelay = 200L
+    override var sequentialMainPageScrollDelay = 200L
     override var name                 = "AnimeciX"
     override val hasMainPage          = true
     override var lang                 = "tr"

--- a/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
+++ b/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
@@ -28,7 +28,7 @@ class AnimeciX : MainAPI() {
     )
 
     override suspend fun getMainPage(page: Int, request: MainPageRequest): HomePageResponse {
-        val response = app.get("${request.data}&page=${page}&perPage=12").parsedSafe<Category>()
+        val response = app.get("${request.data}&page=${page}&perPage=16").parsedSafe<Category>()
 
         val home     = response?.pagination?.data?.mapNotNull { anime ->
             newAnimeSearchResponse(

--- a/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
+++ b/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
@@ -60,7 +60,7 @@ class AnimeciX : MainAPI() {
     override suspend fun load(url: String): LoadResponse? {
         val titleId  = url.substringAfter("?titleId=")
         val uselessResponse = app.get("${mainUrl}/titles/${titleId}/${uselessTitleName}")
-        val response = app.get(url).parsedSafe<Title>() ?: return null
+        val response = app.get("${url}&titleName=${uselessTitleName}").parsedSafe<Title>() ?: return null
 
         val episodes = mutableListOf<Episode>()
         

--- a/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
+++ b/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
@@ -19,12 +19,11 @@ class AnimeciX : MainAPI() {
     override val supportedTypes       = setOf(TvType.Anime)
 
     override val mainPage = mainPageOf(
-        "${mainUrl}/secure/titles?type=series&order=user_score:desc&genre=action&onlyStreamable=true"          to "Aksiyon",
-        "${mainUrl}/secure/titles?type=series&order=user_score:desc&genre=sci-fi-fantasy&onlyStreamable=true"  to "Bilim Kurgu",
-        "${mainUrl}/secure/titles?type=series&order=user_score:desc&genre=drama&onlyStreamable=true"           to "Dram",
-        "${mainUrl}/secure/titles?type=series&order=user_score:desc&genre=mystery&onlyStreamable=true"         to "Gizem",
-        "${mainUrl}/secure/titles?type=series&order=user_score:desc&genre=comedy&onlyStreamable=true"          to "Komedi",
-        "${mainUrl}/secure/titles?type=series&order=user_score:desc&genre=horror&onlyStreamable=true"          to "Korku"
+        "${mainUrl}/secure/titles?genre=action&onlyStreamable=true"          to "Aksiyon",
+        "${mainUrl}/secure/titles?genre=science%20fiction&onlyStreamable=true"  to "Bilim Kurgu",
+        "${mainUrl}/secure/titles?genre=drama&onlyStreamable=true"           to "Dram",
+        "${mainUrl}/secure/titles?genre=magic&onlyStreamable=true"          to "Büyü",
+        "${mainUrl}/secure/titles?genre=isekai&onlyStreamable=true"          to "İsekai"
     )
 
     override suspend fun getMainPage(page: Int, request: MainPageRequest): HomePageResponse {

--- a/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
+++ b/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
@@ -25,7 +25,7 @@ class AnimeciX : MainAPI() {
     )
 
     override suspend fun getMainPage(page: Int, request: MainPageRequest): HomePageResponse {
-        val response = app.get("${request.data}&page=${page}&perPage=16").parsedSafe<Category>()
+        val response = app.get("${request.data}&page=${page}&perPage=16", headers=mapOf("x-e-h" to "7Y2ozlO+QysR5w9Q6Tupmtvl9jJp7ThFH8SB+Lo7NvZjgjqRSqOgcT2v4ISM9sP10LmnlYI8WQ==.xrlyOBFS5BHjQ2Lk")).parsedSafe<Category>()
 
         val home     = response?.pagination?.data?.mapNotNull { anime ->
             newAnimeSearchResponse(

--- a/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
+++ b/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
@@ -31,7 +31,7 @@ class AnimeciX : MainAPI() {
         val home     = response?.pagination?.data?.mapNotNull { anime ->
             newAnimeSearchResponse(
                 anime.title,
-                "${mainUrl}/secure/titles/${anime.id}?titleId=${anime.id}",
+                "${mainUrl}/secure/titles/${anime.id}?titleId=${anime.id}&titleName=${uselessTitleName}",
                 TvType.Anime
             ) {
                 this.posterUrl = fixUrlNull(anime.poster)

--- a/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
+++ b/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
@@ -10,6 +10,9 @@ import com.lagradost.cloudstream3.LoadResponse.Companion.addTrailer
 
 class AnimeciX : MainAPI() {
     override var mainUrl              = "https://animecix.net"
+    override var sequentialMainPage = true
+    override var sequentialMainPageDelay = 200
+    override var sequentialMainPageScrollDelay = 200
     override var name                 = "AnimeciX"
     override val hasMainPage          = true
     override var lang                 = "tr"

--- a/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
+++ b/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
@@ -17,6 +17,7 @@ class AnimeciX : MainAPI() {
     override val hasChromecastSupport = true
     override val hasDownloadSupport   = true
     override val supportedTypes       = setOf(TvType.Anime)
+    val uselessTitleName = "zumzumyehe"
 
     //Animecix'in filtreleme özelliği kendi sitesinde bile düzgün çalışmıyor o yüzden türleri kaldırdım.
     override val mainPage = mainPageOf(
@@ -46,7 +47,7 @@ class AnimeciX : MainAPI() {
         return response.results.mapNotNull { anime ->
             newAnimeSearchResponse(
                 anime.title,
-                "${mainUrl}/secure/titles/${anime.id}?titleId=${anime.id}",
+                "${mainUrl}/secure/titles/${anime.id}?titleId=${anime.id}&titleName=${uselessTitleName}",
                 TvType.Anime
             ) {
                 this.posterUrl = fixUrlNull(anime.poster)
@@ -57,10 +58,12 @@ class AnimeciX : MainAPI() {
     override suspend fun quickSearch(query: String): List<SearchResponse> = search(query)
 
     override suspend fun load(url: String): LoadResponse? {
+        val titleId  = url.substringAfter("?titleId=")
+        val uselessResponse = app.get("${mainUrl}/titles/${titleId}/${uselessTitleName}")
         val response = app.get(url).parsedSafe<Title>() ?: return null
 
         val episodes = mutableListOf<Episode>()
-        val titleId  = url.substringAfter("?titleId=")
+        
 
         if (response.title.title_type == "anime") {
             for (sezon in 1..response.title.season_count) {

--- a/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
+++ b/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
@@ -18,11 +18,10 @@ class AnimeciX : MainAPI() {
     override val hasDownloadSupport   = true
     override val supportedTypes       = setOf(TvType.Anime)
 
+    //Animecix'in filtreleme özelliği kendi sitesinde bile düzgün çalışmıyor o yüzden türleri kaldırdım.
     override val mainPage = mainPageOf(
-        "${mainUrl}/secure/titles?genre=action&onlyStreamable=true"          to "Aksiyon",
-        "${mainUrl}/secure/titles?genre=science%20fiction&onlyStreamable=true"  to "Bilim Kurgu",
-        "${mainUrl}/secure/titles?keyword=magic&onlyStreamable=true"          to "Büyü",
-        "${mainUrl}/secure/titles?keyword=isekai&onlyStreamable=true"          to "İsekai"
+        "${mainUrl}/secure/titles?type=series&onlyStreamable=true"          to "Seriler",
+        "${mainUrl}/secure/titles?type=movie&onlyStreamable=true"  to "Filmler",
     )
 
     override suspend fun getMainPage(page: Int, request: MainPageRequest): HomePageResponse {

--- a/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
+++ b/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
@@ -17,7 +17,6 @@ class AnimeciX : MainAPI() {
     override val hasChromecastSupport = true
     override val hasDownloadSupport   = true
     override val supportedTypes       = setOf(TvType.Anime)
-    val uselessTitleName = "zumzumyehe"
 
     //Animecix'in filtreleme özelliği kendi sitesinde bile düzgün çalışmıyor o yüzden türleri kaldırdım.
     override val mainPage = mainPageOf(
@@ -59,8 +58,7 @@ class AnimeciX : MainAPI() {
 
     override suspend fun load(url: String): LoadResponse? {
         val titleId  = url.substringAfter("?titleId=")
-        val uselessResponse = app.get("${mainUrl}/titles/${titleId}/${uselessTitleName}")
-        val response = app.get("${url}&titleName=${uselessTitleName}").parsedSafe<Title>() ?: return null
+        val response = app.get(url, headers=mapOf("x-e-h" to "7Y2ozlO+QysR5w9Q6Tupmtvl9jJp7ThFH8SB+Lo7NvZjgjqRSqOgcT2v4ISM9sP10LmnlYI8WQ==.xrlyOBFS5BHjQ2Lk")).parsedSafe<Title>() ?: return null
 
         val episodes = mutableListOf<Episode>()
         
@@ -91,7 +89,7 @@ class AnimeciX : MainAPI() {
 
         return newTvSeriesLoadResponse(
             response.title.title,
-            "${mainUrl}/secure/titles/${response.title.id}?titleId=${response.title.id}&titleName=${uselessTitleName}",
+            "${mainUrl}/secure/titles/${response.title.id}?titleId=${response.title.id}",
             TvType.Anime,
             episodes
         ) {

--- a/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
+++ b/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
@@ -21,9 +21,8 @@ class AnimeciX : MainAPI() {
     override val mainPage = mainPageOf(
         "${mainUrl}/secure/titles?genre=action&onlyStreamable=true"          to "Aksiyon",
         "${mainUrl}/secure/titles?genre=science%20fiction&onlyStreamable=true"  to "Bilim Kurgu",
-        "${mainUrl}/secure/titles?genre=drama&onlyStreamable=true"           to "Dram",
-        "${mainUrl}/secure/titles?genre=magic&onlyStreamable=true"          to "Büyü",
-        "${mainUrl}/secure/titles?genre=isekai&onlyStreamable=true"          to "İsekai"
+        "${mainUrl}/secure/titles?keyword=magic&onlyStreamable=true"          to "Büyü",
+        "${mainUrl}/secure/titles?keyword=isekai&onlyStreamable=true"          to "İsekai"
     )
 
     override suspend fun getMainPage(page: Int, request: MainPageRequest): HomePageResponse {

--- a/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
+++ b/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
@@ -91,7 +91,7 @@ class AnimeciX : MainAPI() {
 
         return newTvSeriesLoadResponse(
             response.title.title,
-            "${mainUrl}/secure/titles/${response.title.id}?titleId=${response.title.id}",
+            "${mainUrl}/secure/titles/${response.title.id}?titleId=${response.title.id}&titleName=${uselessTitleName}",
             TvType.Anime,
             episodes
         ) {


### PR DESCRIPTION
Bu pull requestte animecix'in yanlış data dönme sorununa bir el attım. Kodun önceki versiyonunda birkaç tane sorun vardı: Anasayfanın yüklenmemesi, yüklenmeye çalışılan animelerin dışında bir animenin yüklenmesi gibi. Animecix'in API'ının nasıl çalıştığını incelediğimde kodda bulunmayan bir "x-e-h" isimli bir headerın gönderildiğini buldum. 
Bu headerın değerini javascript ile hesaplıyorlar, temel olarak AES encryptionını kullanan bir şey. Headerdaki noktadan önce gelen kısım ciphertext, sonrasında gelen kısım ise initialization vector. Javascript ile debugging yaparken buldum bunları fakat tam olarak neyi şifrelediğini çözemedim. Fakat kendi şifrelediğim bir metini kullandığımda da sitenin veri döndüğünü fark ettim. Yani kısacası ne işler döndüğünü ben de çözemedim. 
Şu an kod sabit bir header dönüyor: `mapOf("x-e-h" to "7Y2ozlO+QysR5w9Q6Tupmtvl9jJp7ThFH8SB+Lo7NvZjgjqRSqOgcT2v4ISM9sP10LmnlYI8WQ==.xrlyOBFS5BHjQ2Lk")` Bu benim generate ettiğim bir header, mantığını kotlin ile yazmadım şu an. Eğer ileride yüklenmeme sorunları alırsak generate etme kodunu da yazabilirim. Şimdilik böyle bir test edersek güzel olur.