### PR TITLE
Fix Animecix season number fetching

### DIFF
--- a/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
+++ b/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciX.kt
@@ -76,8 +76,8 @@ class AnimeciX : MainAPI() {
         val titleId  = url.substringAfter("?titleId=")
 
         if (response.title.title_type == "anime") {
-            for (sezon in 1..response.title.season_count) {
-                val sezonResponse = app.get("${mainUrl}/secure/related-videos?episode=1&season=${sezon}&videoId=0&titleId=${titleId}").parsedSafe<TitleVideos>() ?: return null
+            for (sezon in response.title.seasons) {
+                val sezonResponse = app.get("${mainUrl}/secure/related-videos?episode=1&season=${sezon.number}&videoId=0&titleId=${titleId}").parsedSafe<TitleVideos>() ?: return null
                 for (video in sezonResponse.videos) {
                     episodes.add(Episode(
                         data    = video.url,

--- a/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciXModels.kt
+++ b/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciXModels.kt
@@ -43,7 +43,8 @@ data class Anime(
     @JsonProperty("genres") val tags: List<Genre>,
     @JsonProperty("trailer") val trailer: String?,
     @JsonProperty("credits") val actors: List<Credit>,
-    @JsonProperty("season_count") val season_count: Int,
+    @JsonProperty("season_count") val season_count: Int, //Unrealiable?
+    @JsonProperty("seasons") val seasons: List<Season>,
     @JsonProperty("videos") val videos: List<Video>
 )
 
@@ -65,3 +66,5 @@ data class Video(
 data class TitleVideos(
     @JsonProperty("videos") val videos: List<Video>
 )
+
+data class Season(@JsonProperty("number") val number: Int)


### PR DESCRIPTION
@JsonProperty("season_count") val season_count: Int -> Bu property bazen update edilmemiş sezon sayısı döndürüyor. 
Solo leveling isimli anime 2 sezonken season_count gönderilen responseda sadece 1. 
@JsonProperty("seasons") val seasons: List<Season>, -> Burada sezon listesini çekip onun üzerinden istek yapmak daha safe oluyor