### PR TITLE
Fix AnimeSearch poster property

### DIFF
--- a/AnimeciX/build.gradle.kts
+++ b/AnimeciX/build.gradle.kts
@@ -1,4 +1,4 @@
-version = 5
+version = 6
 
 cloudstream {
     authors     = listOf("keyiflerolsun", "inatchii", "JustRelaxable")

--- a/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciXModels.kt
+++ b/AnimeciX/src/main/kotlin/com/keyiflerolsun/AnimeciXModels.kt
@@ -29,7 +29,7 @@ data class AnimeSearch(
     @JsonProperty("id") val id: Int,
     @JsonProperty("title_type") val title_type: String,
     @JsonProperty("name") val title: String,
-    @JsonProperty("poster") val poster: String,
+    @JsonProperty("poster") val poster: String?,
 )
 
 data class Anime(


### PR DESCRIPTION
Posterin null olduğu zamanlarda parse başarısız oluyor ve hiçbir arama sonucu gösterilmiyor, kono suba diye arattığımda arama sonuçlarında hiçbir şey çıkmazken bu güncelleme ile beraber çıkmaya başlıyor.